### PR TITLE
Ignore key inputs with modifier keys in media

### DIFF
--- a/src/CollectionsOnline.WebSite/content/js/app/media.js
+++ b/src/CollectionsOnline.WebSite/content/js/app/media.js
@@ -77,6 +77,10 @@ module.exports = {
     if ($('input,textarea').is(':focus'))
       return;
 
+    // ignore inputs with modifier keys
+    if (e.ctrlKey || e.metaKey)
+      return;
+
     switch (e.which) {
       case 37: // left arrow
         this.$previous.triggerHandler('click');


### PR DESCRIPTION
This makes it possible to use browser search functions (Command-f or control-f) without accidentally toggling full-screen in the media viewer!