### PR TITLE
Make perpage behaviour more consistent

### DIFF
--- a/src/CollectionsOnline.WebSite/Modules/Api/ApiModuleBase.cs
+++ b/src/CollectionsOnline.WebSite/Modules/Api/ApiModuleBase.cs
@@ -106,8 +106,11 @@ namespace CollectionsOnline.WebSite.Modules.Api
             if (apiInputModel.Page <= 0)
                 apiInputModel.Page = 1;
 
-            if (apiInputModel.PerPage < Constants.PagingPerPageDefault || apiInputModel.PerPage > Constants.PagingPerPageMax)
+            if (apiInputModel.PerPage < 0)
                 apiInputModel.PerPage = Constants.PagingPerPageDefault;
+
+            if (apiInputModel.PerPage > Constants.PagingPerPageMax)
+                apiInputModel.PerPage = Constants.PagingPerPageMax;
 
             ApiInputModel = apiInputModel;
         }

--- a/src/CollectionsOnline.WebSite/Views/DevelopersIndex.cshtml
+++ b/src/CollectionsOnline.WebSite/Views/DevelopersIndex.cshtml
@@ -26,7 +26,7 @@
         <pre>@Model.ApiRootUrl</pre>
 
         <h2 id="pagination">Pagination</h2>
-        <p>Requests that return multiple objects will by default display @Constants.PagingPerPageDefault objects per request, you can increase this to @Constants.PagingPerPageMax by using a <em>?perpage</em> query string parameter.</p>
+        <p>Requests that return a list of objects will by default display @Constants.PagingPerPageDefault objects per request, you can change this to any number up to @Constants.PagingPerPageMax by using a <em>?perpage</em> query string parameter.</p>
         <p>You can also specify a page parameter to retrieve results from different pages via a <em>?page</em> query string parameter.</p>
         <h4>Link Header</h4>
         <p>The actual pagination information is stored in the response headers.  In order to allow easy traversing of data sets refer to the <a href="http://tools.ietf.org/html/rfc5988">Link header</a> to get the next page of objects in your request. E.g</p>


### PR DESCRIPTION
This adjusts the pagination code to allow returning fewer than the default number of items per page, and to reduce requests for more than the maximum to the maximum rather than the default.

The first bit of behaviour is desirable for me as in part of what I'm doing (trying to pick a random item) it's useful for me to be able to query the number of items matched by a query without initially returning any of the content of that query.
My current hack to achieve this is to set the page index to something out of range, (I'm usually using page 1 billion or so) which means I hit your database for a count and _only_ a count so it's blazing fast!

The latter just feels a bit more consistent with what an end-user would want! 😜

Additionally, this updates the documentation to be a bit more clear about the behaviour - as it was I was under the impression only 40 and 100 were valid page size values, but it turns out it was any page size between 40 and 100! :P

Unfortunately I don't have access to Visual Studio to verify this change, so I'd advise giving it a good double-check with some zero-item queries before deploying! 💜